### PR TITLE
Fix missing '\n' with fool-proof solution and change tfvars format to hcl

### DIFF
--- a/cmd/tfvarser/aliyun.go
+++ b/cmd/tfvarser/aliyun.go
@@ -81,10 +81,10 @@ func aliyunAutoscaleObjects(appFlags *Flags, cfg Config) (int, error) {
 		// Scaling Group
 		scalingGroupDir := path.Join(serviceDir, "ess-scaling-group")
 		sgGenerator := tfvars.New(tfvarsaliyun.NewScalingGroup(sg, extras), funcMap)
-		log.Debugf("Generating %v", path.Join(scalingGroupDir, "terraform.tfvars"))
-		err = sgGenerator.Generate(scalingGroupDir, "terraform.tfvars")
+		log.Debugf("Generating %v", path.Join(scalingGroupDir, "terraform.hcl"))
+		err = sgGenerator.Generate(scalingGroupDir, "terraform.hcl")
 		if err != nil {
-			log.Errorf("Error generating %v: %v\n", path.Join(scalingGroupDir, "terraform.tfvars"), err.Error())
+			log.Errorf("Error generating %v: %v\n", path.Join(scalingGroupDir, "terraform.hcl"), err.Error())
 		}
 
 		// Scaling Rule
@@ -105,10 +105,10 @@ func aliyunAutoscaleObjects(appFlags *Flags, cfg Config) (int, error) {
 
 			scalingRuleDir := path.Join(scalingRuleParentDir, strings.TrimPrefix(sr.ScalingRuleName, "tf-"))
 			srGenerator := tfvars.New(tfvarsaliyun.NewScalingRule(sr, sg, extras), funcMap)
-			log.Debugf("Generating %v", path.Join(scalingRuleDir, "terraform.tfvars"))
-			err = srGenerator.Generate(scalingRuleDir, "terraform.tfvars")
+			log.Debugf("Generating %v", path.Join(scalingRuleDir, "terraform.hcl"))
+			err = srGenerator.Generate(scalingRuleDir, "terraform.hcl")
 			if err != nil {
-				log.Errorf("Error generating %v: %v\n", path.Join(scalingRuleDir, "terraform.tfvars"), err.Error())
+				log.Errorf("Error generating %v: %v\n", path.Join(scalingRuleDir, "terraform.hcl"), err.Error())
 			}
 		}
 
@@ -136,10 +136,10 @@ func aliyunAutoscaleObjects(appFlags *Flags, cfg Config) (int, error) {
 
 			alarmDir := path.Join(alarmParentDir, strings.TrimPrefix(al.AlarmName, "tf-"))
 			alGenerator := tfvars.New(tfvarsaliyun.NewAlarm(al, sg, sr, extras), funcMap)
-			log.Debugf("Generating %v", path.Join(alarmDir, "terraform.tfvars"))
-			err = alGenerator.Generate(alarmDir, "terraform.tfvars")
+			log.Debugf("Generating %v", path.Join(alarmDir, "terraform.hcl"))
+			err = alGenerator.Generate(alarmDir, "terraform.hcl")
 			if err != nil {
-				log.Errorf("Error generating %v: %v\n", path.Join(alarmDir, "terraform.tfvars"), err.Error())
+				log.Errorf("Error generating %v: %v\n", path.Join(alarmDir, "terraform.hcl"), err.Error())
 			}
 		}
 
@@ -160,10 +160,10 @@ func aliyunAutoscaleObjects(appFlags *Flags, cfg Config) (int, error) {
 
 			lifecycleHookDir := path.Join(lifecycleHookParentDir, lh.LifecycleHookName)
 			lhGenerator := tfvars.New(tfvarsaliyun.NewLifecycleHook(lh, sg, extras), funcMap)
-			log.Debugf("Generating %v", path.Join(lifecycleHookDir, "terraform.tfvars"))
-			err = lhGenerator.Generate(lifecycleHookDir, "terraform.tfvars")
+			log.Debugf("Generating %v", path.Join(lifecycleHookDir, "terraform.hcl"))
+			err = lhGenerator.Generate(lifecycleHookDir, "terraform.hcl")
 			if err != nil {
-				log.Errorf("Error generating %v: %v\n", path.Join(lifecycleHookDir, "terraform.tfvars"), err.Error())
+				log.Errorf("Error generating %v: %v\n", path.Join(lifecycleHookDir, "terraform.hcl"), err.Error())
 			}
 		}
 
@@ -183,10 +183,10 @@ func aliyunAutoscaleObjects(appFlags *Flags, cfg Config) (int, error) {
 
 			scalingConfigurationDir := path.Join(scalingConfigurationParentDir, strings.TrimPrefix(sc.ScalingConfigurationName, "tf-"))
 			scGenerator := tfvars.New(tfvarsaliyun.NewScalingConfiguration(sc, sg, extras), funcMap)
-			log.Debugf("Generating %v", path.Join(scalingConfigurationDir, "terraform.tfvars"))
-			err = scGenerator.Generate(scalingConfigurationDir, "terraform.tfvars")
+			log.Debugf("Generating %v", path.Join(scalingConfigurationDir, "terraform.hcl"))
+			err = scGenerator.Generate(scalingConfigurationDir, "terraform.hcl")
 			if err != nil {
-				log.Errorf("Error generating %v: %v\n", path.Join(scalingConfigurationDir, "terraform.tfvars"), err.Error())
+				log.Errorf("Error generating %v: %v\n", path.Join(scalingConfigurationDir, "terraform.hcl"), err.Error())
 			}
 		}
 	}

--- a/tfvars/aliyun/alarm.go
+++ b/tfvars/aliyun/alarm.go
@@ -49,37 +49,37 @@ func (s *Alarm) Execute(w io.Writer, tmpl *template.Template) error {
 
 // Template returns the template
 func (s *Alarm) Template() string {
-	tmpl := `terragrunt = {
-  include {
-    path = "${find_in_parent_folders()}"
-  }
-  terraform {
-    source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-alarm"
-  }
+	tmpl := `include {
+  path = "${find_in_parent_folders()}"
 }
 
-# ESS scaling group (ID: {{ .ScalingGroupID }})
-esssg_remote_state_bucket = "tkpd-tg-alicloud"
-esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
+terraform {
+  source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-alarm"
+}
 
-# ESS scaling rule
-esssr_remote_state_bucket = "tkpd-tg-alicloud"
-esssr_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-rules/{{ trimPrefix .ScalingRule.ScalingRuleName "tf-" }}/terraform.tfstate"
+input = {
+  # ESS Scaling Group (ID: {{ .ScalingGroupID }})
+  esssg_remote_state_bucket = "tkpd-tg-alicloud"
+  esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
 
-# ESS alarm
-essa_name                = "{{ trimPrefix .AlarmName "tf-" }}"
-essa_enable              = {{ .Enable }}
-essa_metric_type         = "{{ .MetricType }}"
-essa_metric_name         = "{{ .MetricName }}"
-essa_period              = {{ .Period }}
-essa_statistics          = "{{ .Statistics }}"
-essa_comparison_operator = "{{ .ComparisonOperator }}"
-essa_threshold           = {{ .Threshold }}
-essa_evaluation_count    = {{ .EvaluationCount }}
+  # ESS Scaling Rule
+  esssr_remote_state_bucket = "tkpd-tg-alicloud"
+  esssr_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-rules/{{ trimPrefix .ScalingRule.ScalingRuleName "tf-" }}/terraform.tfstate"
+
+  # ESS Alarm
+  essa_name                = "{{ trimPrefix .AlarmName "tf-" }}"
+  essa_enable              = {{ .Enable }}
+  essa_metric_type         = "{{ .MetricType }}"
+  essa_metric_name         = "{{ .MetricName }}"
+  essa_period              = {{ .Period }}
+  essa_statistics          = "{{ .Statistics }}"
+  essa_comparison_operator = "{{ .ComparisonOperator }}"
+  essa_threshold           = {{ .Threshold }}
+  essa_evaluation_count    = {{ .EvaluationCount }}
+}
 
 # Import command
-# terragrunt import alicloud_ess_alarm.essa {{ .AlarmID }}
-`
+# terragrunt import alicloud_ess_alarm.essa {{ .AlarmID }}`
 
 	return tmpl
 }

--- a/tfvars/aliyun/lifecycleHook.go
+++ b/tfvars/aliyun/lifecycleHook.go
@@ -47,32 +47,32 @@ func (s *LifecycleHook) Execute(w io.Writer, tmpl *template.Template) error {
 
 // Template returns the template
 func (s *LifecycleHook) Template() string {
-	tmpl := `terragrunt = {
-  include {
-    path = "${find_in_parent_folders()}"
-  }
-  terraform {
-    source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-lifecycle-hook"
-  }
+	tmpl := `include {
+  path = "${find_in_parent_folders()}"
 }
 
-# ESS scaling group (ID: {{ .ScalingGroup.ScalingGroupID }})
-esssg_remote_state_bucket = "tkpd-tg-alicloud"
-esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
+terraform {
+  source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-lifecycle-hook"
+}
 
-# MNS queue
-mq_remote_state_bucket = "tkpd-tg-alicloud"
-mq_remote_state_key    = "general/mns-queues/{{ if eq .LifecycleTransition "SCALE_IN" }}autoscaledown-event{{ else }}autoscaleup-event{{ end }}/terraform.tfstate"
+input = {
+  # ESS Scaling Group (ID: {{ .ScalingGroup.ScalingGroupID }})
+  esssg_remote_state_bucket = "tkpd-tg-alicloud"
+  esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
 
-# ESS lifecycle hook
-esslh_name                 = "{{ .LifecycleHookName }}"
-esslh_lifecycle_transition = "{{ .LifecycleTransition }}"
-esslh_default_result       = "{{ .DefaultResult }}"
-esslh_heartbeat_timeout    = {{ .HeartbeatTimeout }}
+  # MNS Queue
+  mq_remote_state_bucket = "tkpd-tg-alicloud"
+  mq_remote_state_key    = "general/mns-queues/{{ if eq .LifecycleTransition "SCALE_IN" }}autoscaledown-event{{ else }}autoscaleup-event{{ end }}/terraform.tfstate"
+
+  # ESS Lifecycle Hook
+  esslh_name                 = "{{ .LifecycleHookName }}"
+  esslh_lifecycle_transition = "{{ .LifecycleTransition }}"
+  esslh_default_result       = "{{ .DefaultResult }}"
+  esslh_heartbeat_timeout    = {{ .HeartbeatTimeout }}
+}
 
 # Import command
-# terragrunt import alicloud_ess_lifecycle_hook.esslh {{ .LifecycleHookID }}
-`
+# terragrunt import alicloud_ess_lifecycle_hook.esslh {{ .LifecycleHookID }}`
 
 	return tmpl
 }

--- a/tfvars/aliyun/scalingConfiguration.go
+++ b/tfvars/aliyun/scalingConfiguration.go
@@ -47,55 +47,54 @@ func (s *ScalingConfiguration) Execute(w io.Writer, tmpl *template.Template) err
 
 // Template returns the template
 func (s *ScalingConfiguration) Template() string {
-	tmpl := `terragrunt = {
-  include {
-    path = "${find_in_parent_folders()}"
-  }
-  terraform {
-    source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-scaling-configuration"
-  }
+	tmpl := `include {
+  path = "${find_in_parent_folders()}"
 }
 
-# ESS Scaling group (ID: {{ .ScalingGroup.ScalingGroupID }})
-esssg_remote_state_bucket = "tkpd-tg-alicloud"
-esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
-
-# ECS Security group
-sg_remote_state_bucket = "tkpd-tg-alicloud-infra"
-sg_remote_state_key    = "security-groups/intranet/security-group/terraform.tfstate"
-
-# ECS Images
-images_name_regex = "^{{ index .Extras "imageName" }}$"
-
-# ESS Scaling configuration
-esssc_scaling_configuration_name = "{{ trimPrefix .ScalingConfigurationName "tf-" }}"
-esssc_instance_name              = "{{ index .Extras "serviceName" }}"
-esssc_instance_types             = [
-{{ range $index, $element := .InstanceTypes }}{{- if $index }},
-{{- end }}{{- if not $index }} {{ end }} "{{ $element -}}"{{ end }}
-]
-esssc_enable                     = {{ .Enable }}
-esssc_active                     = {{ .Active }}
-esssc_key_name                   = "{{ .KeyPairName }}"
-esssc_role_name                  = "{{ .RAMRoleName }}"
-
-esssc_user_data = <<EOF
-{{ .UserData -}}
-
-EOF
-
-esssc_tags_tribe     = "{{ if .Tags.tribe }}{{ index .Tags "tribe" }}{{ end }}"
-esssc_tags_team      = "{{ if .Tags.team }}{{ index .Tags "team" }}{{ end }}"
-esssc_tags_hostgroup = "{{ if .Tags.hostgroup }}{{ index .Tags "hostgroup" }}{{ end }}"
-esssc_tags_type      = "{{ if .Tags.type }}{{ index .Tags "type" }}{{ end }}"
-{{ if .Tags.consul_tags }}
-esssc_optional_tags = {
-  "consul_tags" = "{{ index .Tags "consul_tags" }}"
+terraform {
+  source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-scaling-configuration"
 }
-{{ end }}
+
+input = {
+  # ESS Scaling Group (ID: {{ .ScalingGroup.ScalingGroupID }})
+  esssg_remote_state_bucket = "tkpd-tg-alicloud"
+  esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
+
+  # ECS Security Group
+  sg_remote_state_bucket = "tkpd-tg-alicloud-infra"
+  sg_remote_state_key    = "security-groups/intranet/security-group/terraform.tfstate"
+
+  # ECS Images
+  images_name_regex = "^{{ index .Extras "imageName" }}$"
+
+  # ESS Scaling configuration
+  esssc_scaling_configuration_name = "{{ trimPrefix .ScalingConfigurationName "tf-" }}"
+  esssc_instance_name              = "{{ index .Extras "serviceName" }}"
+  esssc_instance_types             = [
+  {{ range $index, $element := .InstanceTypes }}{{- if $index }},
+  {{- end }}{{- if not $index }} {{ end }} "{{ $element -}}"{{ end }}
+  ]
+  esssc_enable                     = {{ .Enable }}
+  esssc_active                     = {{ .Active }}
+  esssc_key_name                   = "{{ .KeyPairName }}"
+  esssc_role_name                  = "{{ .RAMRoleName }}"
+
+  esssc_user_data = <<EOF
+{{ printf "%s" .UserData -}}
+{{ printf "\n  %s" "EOF" }}
+
+  esssc_tags_tribe     = "{{ if .Tags.tribe }}{{ index .Tags "tribe" }}{{ end }}"
+  esssc_tags_team      = "{{ if .Tags.team }}{{ index .Tags "team" }}{{ end }}"
+  esssc_tags_hostgroup = "{{ if .Tags.hostgroup }}{{ index .Tags "hostgroup" }}{{ end }}"
+  esssc_tags_type      = "{{ if .Tags.type }}{{ index .Tags "type" }}{{ end }}"
+  {{- if .Tags.consul_tags }}
+  esssc_optional_tags = {
+    "consul_tags" = "{{ index .Tags "consul_tags" }}"
+  }{{ end }}
+}
+
 # Import command
-# terragrunt import alicloud_ess_scaling_configuration.esssc {{ .ScalingConfigurationID }}
-`
+# terragrunt import alicloud_ess_scaling_configuration.esssc {{ .ScalingConfigurationID }}`
 
 	return tmpl
 }

--- a/tfvars/aliyun/scalingGroup.go
+++ b/tfvars/aliyun/scalingGroup.go
@@ -45,43 +45,43 @@ func (s *ScalingGroup) Execute(w io.Writer, tmpl *template.Template) error {
 
 // Template returns the template
 func (s *ScalingGroup) Template() string {
-	tmpl := `terragrunt = {
-  include {
-    path = "${find_in_parent_folders()}"
-  }
-  terraform {
-    source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-scaling-group"
-  }
+	tmpl := `include {
+  path = "${find_in_parent_folders()}"
 }
 
-# VPC VSwitch
-vsw_remote_state_bucket = "tkpd-tg-alicloud-infra"
-vsw_remote_state_keys   = [
-   "vswitches/app/terraform.tfstate",
-   "vswitches/app-2/terraform.tfstate"
-]
+terraform {
+  source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-scaling-group"
+}
 
-# ESS Scaling Group
-esssg_name = "{{ trimPrefix .ScalingGroupName "tf-" }}"
+input = {
+  # VPC VSwitch
+  vsw_remote_state_bucket = "tkpd-tg-alicloud-infra"
+  vsw_remote_state_keys   = [
+     "vswitches/app/terraform.tfstate",
+     "vswitches/app-2/terraform.tfstate"
+  ]
 
-esssg_min_size = {{ .MinSize }}
-esssg_max_size = {{ .MaxSize }}
+  # ESS Scaling Group
+  esssg_name = "{{ trimPrefix .ScalingGroupName "tf-" }}"
 
-esssg_removal_policies = [
-{{ range $index, $element := .RemovalPolicies }}{{- if $index }},
-{{- end }}{{ if not $index }} {{ end }} "{{ $element -}}"{{ end }}
-]
+  esssg_min_size = {{ .MinSize }}
+  esssg_max_size = {{ .MaxSize }}
 
-esssg_multi_az_policy  = "{{ .MultiAZPolicy }}"
-{{ if .LoadBalancerIDs }}
-esssg_loadbalancer_ids = [
-{{ range $index, $element := .LoadBalancerIDs }}{{- if $index }},
-{{- end }}{{ if not $index }} {{ end }} "{{ $element -}}"{{ end }}
-]
-{{ end }}
+  esssg_removal_policies = [
+  {{ range $index, $element := .RemovalPolicies }}{{- if $index }},
+  {{- end }}{{ if not $index }} {{ end }} "{{ $element -}}"{{ end }}
+  ]
+
+  esssg_multi_az_policy  = "{{ .MultiAZPolicy }}"
+  {{- if .LoadBalancerIDs }}
+  esssg_loadbalancer_ids = [
+  {{ range $index, $element := .LoadBalancerIDs }}{{- if $index }},
+  {{- end }}{{ if not $index }} {{ end }} "{{ $element -}}"{{ end }}
+  ]{{ end }}
+}
+
 # Import command
-# terragrunt import alicloud_ess_scaling_group.esssg {{ .ScalingGroupID }}
-`
+# terragrunt import alicloud_ess_scaling_group.esssg {{ .ScalingGroupID }}`
 
 	return tmpl
 }

--- a/tfvars/aliyun/scalingRule.go
+++ b/tfvars/aliyun/scalingRule.go
@@ -47,28 +47,28 @@ func (s *ScalingRule) Execute(w io.Writer, tmpl *template.Template) error {
 
 // Template returns the template
 func (s *ScalingRule) Template() string {
-	tmpl := `terragrunt = {
-  include {
-    path = "${find_in_parent_folders()}"
-  }
-  terraform {
-    source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-scaling-rule"
-  }
+	tmpl := `include {
+  path = "${find_in_parent_folders()}"
 }
 
-# ESS scaling group (ID: {{ .ScalingGroup.ScalingGroupID }})
-esssg_remote_state_bucket = "tkpd-tg-alicloud"
-esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
+terraform {
+  source = "git::git@github.com:tokopedia/tf-alicloud-modules.git//ess-scaling-rule"
+}
 
-# ESS scaling rule
-esssr_scaling_rule_name = "{{ trimPrefix .ScalingRuleName "tf-" }}"
-esssr_adjustment_type   = "{{ .AdjustmentType }}"
-esssr_adjustment_value  = "{{ .AdjustmentValue }}"
-esssr_cooldown          = {{ .Cooldown }}
+input = {
+  # ESS Scaling Group (ID: {{ .ScalingGroup.ScalingGroupID }})
+  esssg_remote_state_bucket = "tkpd-tg-alicloud"
+  esssg_remote_state_key    = "{{ index .Extras "serviceName" }}/autoscale/ess-scaling-group/terraform.tfstate"
+
+  # ESS Scaling Rule
+  esssr_scaling_rule_name = "{{ trimPrefix .ScalingRuleName "tf-" }}"
+  esssr_adjustment_type   = "{{ .AdjustmentType }}"
+  esssr_adjustment_value  = "{{ .AdjustmentValue }}"
+  esssr_cooldown          = {{ .Cooldown }}
+}
 
 # Import command
-# terragrunt import alicloud_ess_scaling_rule.esssr {{ .ScalingRuleID }}
-`
+# terragrunt import alicloud_ess_scaling_rule.esssr {{ .ScalingRuleID }}`
 
 	return tmpl
 }


### PR DESCRIPTION
* Fix missing newline on dynamic values that might/might not have newline at the end
* Change tfvars format to hcl
* Fix extra newline after `esssg_multi_az_policy`
* Fix weird newlines after/before each tags in scaling configuration
* Add missing tab on userdata template